### PR TITLE
resolved tinyxml2 to use ros-provided version using tinyxml2-vendor p…

### DIFF
--- a/capabilities2_fabric/CMakeLists.txt
+++ b/capabilities2_fabric/CMakeLists.txt
@@ -10,36 +10,27 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# find dependencies
+# Find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
+find_package(rclcpp_components REQUIRED)
 find_package(capabilities2_msgs REQUIRED)
+find_package(tinyxml2_vendor REQUIRED)
+find_package(TinyXML2 REQUIRED)  # provided by tinyxml2 upstream, or tinyxml2_vendor
 find_package(bondcpp REQUIRED)
 find_package(backward_ros REQUIRED)
-find_package(rclcpp_components REQUIRED)
 
-# Locate the static version of tinyxml2
-find_library(TINYXML2_LIB NAMES tinyxml2 PATHS /usr/local/lib NO_DEFAULT_PATH)
-
-if(NOT TINYXML2_LIB)
-  message(FATAL_ERROR "tinyxml2 library not found. Make sure it's installed as a static library.")
-endif()
-
-include_directories(include
-  /usr/local/include
+include_directories(
+  include
 )
 
 ############################################################################
-# capabilities2_fabric node implementation that compiles as a executable 
+# capabilities2_fabric node executable
 ############################################################################
 
 add_executable(${PROJECT_NAME}
   src/capabilities_fabric_node.cpp
-)
-
-target_link_libraries(${PROJECT_NAME}
-  ${TINYXML2_LIB}
 )
 
 ament_target_dependencies(${PROJECT_NAME}
@@ -47,6 +38,7 @@ ament_target_dependencies(${PROJECT_NAME}
   rclcpp_action
   bondcpp
   capabilities2_msgs
+  TinyXML2
 )
 
 install(TARGETS ${PROJECT_NAME}
@@ -54,15 +46,11 @@ install(TARGETS ${PROJECT_NAME}
 )
 
 ############################################################################
-# capabilities2_fabric component implementation that compiles as a library 
+# capabilities2_fabric component library
 ############################################################################
 
 add_library(${PROJECT_NAME}_comp SHARED
   src/capabilities_fabric_comp.cpp
-)
-
-target_link_libraries(${PROJECT_NAME}_comp
-  ${TINYXML2_LIB}
 )
 
 ament_target_dependencies(${PROJECT_NAME}_comp
@@ -71,6 +59,7 @@ ament_target_dependencies(${PROJECT_NAME}_comp
   rclcpp_components
   bondcpp
   capabilities2_msgs
+  TinyXML2
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}_comp
@@ -88,37 +77,30 @@ install(TARGETS ${PROJECT_NAME}_comp
 )
 
 ############################################################################
-# fabric_client node implementation that compiles as a executable 
+# fabric_client node executable
 ############################################################################
 
 add_executable(fabric_client
   src/capabilities_fabric_client_node.cpp
 )
 
-target_link_libraries(fabric_client
-  ${TINYXML2_LIB}
-)
-
 ament_target_dependencies(fabric_client
   rclcpp
   rclcpp_action
   capabilities2_msgs
+  TinyXML2
 )
 
 install(TARGETS fabric_client
-    DESTINATION lib/${PROJECT_NAME}
+  DESTINATION lib/${PROJECT_NAME}
 )
 
 ############################################################################
-# fabric_client component implementation that compiles as a library 
+# fabric_client component library
 ############################################################################
 
 add_library(fabric_client_comp SHARED
   src/capabilities_fabric_client_comp.cpp
-)
-
-target_link_libraries(fabric_client_comp
-  ${TINYXML2_LIB}
 )
 
 ament_target_dependencies(fabric_client_comp
@@ -127,6 +109,7 @@ ament_target_dependencies(fabric_client_comp
   rclcpp_components
   bondcpp
   capabilities2_msgs
+  TinyXML2
 )
 
 rclcpp_components_register_node(fabric_client_comp
@@ -144,7 +127,7 @@ install(TARGETS fabric_client_comp
 )
 
 ############################################################################
-# miscellaneous
+# Miscellaneous installations
 ############################################################################
 
 install(DIRECTORY include/
@@ -162,6 +145,5 @@ install(DIRECTORY config
 install(DIRECTORY plans
   DESTINATION share/${PROJECT_NAME}
 )
-
 
 ament_package()

--- a/capabilities2_fabric/include/capabilities2_fabric/capabilities_fabric_client.hpp
+++ b/capabilities2_fabric/include/capabilities2_fabric/capabilities_fabric_client.hpp
@@ -4,9 +4,9 @@
 #include <vector>
 #include <deque>
 #include <algorithm>
-#include <tinyxml2.h>
 #include <functional>
 #include <future>
+#include <tinyxml2.h>
 
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>

--- a/capabilities2_fabric/include/capabilities2_fabric/utils/xml_parser.hpp
+++ b/capabilities2_fabric/include/capabilities2_fabric/utils/xml_parser.hpp
@@ -1,7 +1,7 @@
 #pragma once
-#include <tinyxml2.h>
 #include <string>
 #include <vector>
+#include <tinyxml2.h>
 #include <rclcpp/rclcpp.hpp>
 #include <capabilities2_fabric/utils/connection.hpp>
 #include <capabilities2_fabric/utils/status_client.hpp>

--- a/capabilities2_fabric/package.xml
+++ b/capabilities2_fabric/package.xml
@@ -14,10 +14,7 @@
   <depend>capabilities2_msgs</depend>
   <depend>rclcpp_action</depend>
   <depend>backward_ros</depend> 
-  <depend>capabilities2_utils</depend>
-
-  <!-- system dependency -->
-  <depend>tinyxml2</depend>
+  <depend>tinyxml2_vendor</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/capabilities2_runner/CMakeLists.txt
+++ b/capabilities2_runner/CMakeLists.txt
@@ -10,31 +10,20 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+include_directories(
+  include
+)
+
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(capabilities2_msgs REQUIRED)
-
-# Locate the static version of tinyxml2
-find_library(TINYXML2_LIB NAMES tinyxml2 PATHS /usr/local/lib NO_DEFAULT_PATH)
-
-if(NOT TINYXML2_LIB)
-  message(FATAL_ERROR "tinyxml2 library not found. Make sure it's installed as a static library.")
-endif()
-
-include_directories(include
-  /usr/local/include
-)
+find_package(tinyxml2_vendor REQUIRED)
+find_package(TinyXML2 REQUIRED)  # provided by tinyxml2 upstream, or tinyxml2_vendor
 
 add_library(${PROJECT_NAME} SHARED
   src/standard_runners.cpp
-  # src/launch_runner.cpp
-  # src/action_runner.cpp
-)
-
-target_link_libraries(${PROJECT_NAME}
-  ${TINYXML2_LIB}
 )
 
 ament_target_dependencies(${PROJECT_NAME}
@@ -42,6 +31,7 @@ ament_target_dependencies(${PROJECT_NAME}
   rclcpp_action
   pluginlib
   capabilities2_msgs
+  TinyXML2
 )
 
 pluginlib_export_plugin_description_file(${PROJECT_NAME} plugins.xml)

--- a/capabilities2_runner/include/capabilities2_runner/action_runner.hpp
+++ b/capabilities2_runner/include/capabilities2_runner/action_runner.hpp
@@ -5,8 +5,8 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
-#include <tinyxml2.h>
 
+#include <tinyxml2.h>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <action_msgs/srv/cancel_goal.hpp>

--- a/capabilities2_runner/include/capabilities2_runner/service_runner.hpp
+++ b/capabilities2_runner/include/capabilities2_runner/service_runner.hpp
@@ -1,8 +1,8 @@
 #pragma once
-#include <tinyxml2.h>
 
 #include "rclcpp/rclcpp.hpp"
 
+#include <tinyxml2.h>
 #include <capabilities2_runner/runner_base.hpp>
 
 namespace capabilities2_runner

--- a/capabilities2_runner/include/capabilities2_runner/topic_runner.hpp
+++ b/capabilities2_runner/include/capabilities2_runner/topic_runner.hpp
@@ -1,9 +1,8 @@
 #pragma once
-#include <tinyxml2.h>
 #include <memory>
 
 #include "rclcpp/rclcpp.hpp"
-
+#include <tinyxml2.h>
 #include <capabilities2_runner/runner_base.hpp>
 
 namespace capabilities2_runner

--- a/capabilities2_runner/package.xml
+++ b/capabilities2_runner/package.xml
@@ -20,10 +20,10 @@
   <depend>pluginlib</depend>
   <depend>std_msgs</depend>
   <depend>capabilities2_msgs</depend>
+  <depend>tinyxml2_vendor</depend>
 
   <!-- system dependency -->
   <depend>uuid</depend>
-  <depend>tinyxml2</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/capabilities2_runner_audio/CMakeLists.txt
+++ b/capabilities2_runner_audio/CMakeLists.txt
@@ -18,24 +18,15 @@ find_package(pluginlib REQUIRED)
 find_package(hri_audio_msgs REQUIRED)
 find_package(capabilities2_msgs REQUIRED)
 find_package(capabilities2_runner REQUIRED)
+find_package(tinyxml2_vendor REQUIRED)
+find_package(TinyXML2 REQUIRED)  # provided by tinyxml2 upstream, or tinyxml2_vendor
 
-# Locate the static version of tinyxml2
-find_library(TINYXML2_LIB NAMES tinyxml2 PATHS /usr/local/lib NO_DEFAULT_PATH)
-
-if(NOT TINYXML2_LIB)
-  message(FATAL_ERROR "tinyxml2 library not found. Make sure it's installed as a static library.")
-endif()
-
-include_directories(include
-  /usr/local/include
+include_directories(
+  include
 )
 
 add_library(${PROJECT_NAME} SHARED
   src/audio_runners.cpp
-)
-
-target_link_libraries(${PROJECT_NAME}
-  ${TINYXML2_LIB}
 )
 
 ament_target_dependencies(${PROJECT_NAME}
@@ -45,6 +36,7 @@ ament_target_dependencies(${PROJECT_NAME}
   hri_audio_msgs
   capabilities2_msgs
   capabilities2_runner
+  TinyXML2
 )
 
 pluginlib_export_plugin_description_file(capabilities2_runner plugins.xml)

--- a/capabilities2_runner_audio/include/capabilities2_runner_audio/listen_runner.hpp
+++ b/capabilities2_runner_audio/include/capabilities2_runner_audio/listen_runner.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <thread>
-#include <tinyxml2.h>
 
+#include <tinyxml2.h>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 

--- a/capabilities2_runner_audio/include/capabilities2_runner_audio/speak_runner.hpp
+++ b/capabilities2_runner_audio/include/capabilities2_runner_audio/speak_runner.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <thread>
-#include <tinyxml2.h>
 
+#include <tinyxml2.h>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 

--- a/capabilities2_runner_audio/package.xml
+++ b/capabilities2_runner_audio/package.xml
@@ -17,10 +17,9 @@
   <depend>hri_audio_msgs</depend>
   <depend>capabilities2_msgs</depend>
   <depend>capabilities2_runner</depend>
+  <depend>tinyxml2_vendor</depend>
 
   <!-- system dependency -->
-  <depend>tinyxml2</depend>
-
   <exec_depend>ros2launch</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/capabilities2_runner_bt/CMakeLists.txt
+++ b/capabilities2_runner_bt/CMakeLists.txt
@@ -17,24 +17,15 @@ find_package(pluginlib REQUIRED)
 find_package(capabilities2_msgs REQUIRED)
 find_package(capabilities2_runner REQUIRED)
 find_package(behaviortree_cpp REQUIRED)
+find_package(tinyxml2_vendor REQUIRED)
+find_package(TinyXML2 REQUIRED)  # provided by tinyxml2 upstream, or tinyxml2_vendor
 
-# Locate the static version of tinyxml2
-find_library(TINYXML2_LIB NAMES tinyxml2 PATHS /usr/local/lib NO_DEFAULT_PATH)
-
-if(NOT TINYXML2_LIB)
-  message(FATAL_ERROR "tinyxml2 library not found. Make sure it's installed as a static library.")
-endif()
-
-include_directories(include
-  /usr/local/include
+include_directories(
+  include
 )
 
 add_library(${PROJECT_NAME} SHARED
   src/bt_runners.cpp
-)
-
-target_link_libraries(${PROJECT_NAME}
-  ${TINYXML2_LIB}
 )
 
 ament_target_dependencies(${PROJECT_NAME}
@@ -44,6 +35,7 @@ ament_target_dependencies(${PROJECT_NAME}
   capabilities2_msgs
   capabilities2_runner
   behaviortree_cpp
+  TinyXML2
 )
 
 pluginlib_export_plugin_description_file(capabilities2_runner plugins.xml)

--- a/capabilities2_runner_bt/package.xml
+++ b/capabilities2_runner_bt/package.xml
@@ -21,11 +21,11 @@
   <depend>std_msgs</depend>
   <depend>capabilities2_msgs</depend>
   <depend>capabilities2_runner</depend>
+  <depend>tinyxml2_vendor</depend>
   <depend>behaviortree_cpp</depend>
 
   <!-- system dependency -->
   <depend>uuid</depend>
-  <depend>tinyxml2</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/capabilities2_runner_capabilities/CMakeLists.txt
+++ b/capabilities2_runner_capabilities/CMakeLists.txt
@@ -16,24 +16,15 @@ find_package(rclcpp_action REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(capabilities2_msgs REQUIRED)
 find_package(capabilities2_runner REQUIRED)
+find_package(tinyxml2_vendor REQUIRED)
+find_package(TinyXML2 REQUIRED)  # provided by tinyxml2 upstream, or tinyxml2_vendor
 
-# Locate the static version of tinyxml2
-find_library(TINYXML2_LIB NAMES tinyxml2 PATHS /usr/local/lib NO_DEFAULT_PATH)
-
-if(NOT TINYXML2_LIB)
-  message(FATAL_ERROR "tinyxml2 library not found. Make sure it's installed as a static library.")
-endif()
-
-include_directories(include
-  /usr/local/include
+include_directories(
+  include
 )
 
 add_library(${PROJECT_NAME} SHARED
   src/capabilities2_runner.cpp
-)
-
-target_link_libraries(${PROJECT_NAME}
-  ${TINYXML2_LIB}
 )
 
 ament_target_dependencies(${PROJECT_NAME}
@@ -42,6 +33,7 @@ ament_target_dependencies(${PROJECT_NAME}
   pluginlib
   capabilities2_msgs
   capabilities2_runner
+  TinyXML2
 )
 
 pluginlib_export_plugin_description_file(capabilities2_runner plugins.xml)

--- a/capabilities2_runner_capabilities/include/capabilities2_runner_capabilities/fabric_completion_runner.hpp
+++ b/capabilities2_runner_capabilities/include/capabilities2_runner_capabilities/fabric_completion_runner.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include <tinyxml2.h>
 #include <string>
+#include <tinyxml2.h>
 #include <pluginlib/class_list_macros.hpp>
 #include <capabilities2_runner/service_runner.hpp>
 #include <capabilities2_msgs/srv/complete_fabric.hpp>

--- a/capabilities2_runner_capabilities/package.xml
+++ b/capabilities2_runner_capabilities/package.xml
@@ -18,10 +18,8 @@
   <depend>std_msgs</depend>
   <depend>capabilities2_msgs</depend>
   <depend>capabilities2_runner</depend>
+  <depend>tinyxml2_vendor</depend>
 
-  <!-- system dependency -->
-  <depend>tinyxml2</depend>
-  
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/capabilities2_runner_nav2/CMakeLists.txt
+++ b/capabilities2_runner_nav2/CMakeLists.txt
@@ -20,24 +20,15 @@ find_package(tf2_ros REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(capabilities2_msgs REQUIRED)
 find_package(capabilities2_runner REQUIRED)
+find_package(tinyxml2_vendor REQUIRED)
+find_package(TinyXML2 REQUIRED)  # provided by tinyxml2 upstream, or tinyxml2_vendor
 
-# Locate the static version of tinyxml2
-find_library(TINYXML2_LIB NAMES tinyxml2 PATHS /usr/local/lib NO_DEFAULT_PATH)
-
-if(NOT TINYXML2_LIB)
-  message(FATAL_ERROR "tinyxml2 library not found. Make sure it's installed as a static library.")
-endif()
-
-include_directories(include
-  /usr/local/include
+include_directories(
+  include
 )
 
 add_library(${PROJECT_NAME} SHARED
   src/nav2_runners.cpp
-)
-
-target_link_libraries(${PROJECT_NAME}
-  ${TINYXML2_LIB}
 )
 
 ament_target_dependencies(${PROJECT_NAME}
@@ -50,6 +41,7 @@ ament_target_dependencies(${PROJECT_NAME}
   geometry_msgs
   capabilities2_msgs
   capabilities2_runner
+  TinyXML2
 )
 
 pluginlib_export_plugin_description_file(capabilities2_runner plugins.xml)

--- a/capabilities2_runner_nav2/include/capabilities2_runner_nav2/occupancygrid_runner.hpp
+++ b/capabilities2_runner_nav2/include/capabilities2_runner_nav2/occupancygrid_runner.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <tinyxml2.h>
 #include <rclcpp/rclcpp.hpp>
 
+#include <tinyxml2.h>
 #include <nav_msgs/msg/occupancy_grid.hpp>
 
 #include <capabilities2_runner/topic_runner.hpp>

--- a/capabilities2_runner_nav2/include/capabilities2_runner_nav2/robotpose_runner.hpp
+++ b/capabilities2_runner_nav2/include/capabilities2_runner_nav2/robotpose_runner.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <tinyxml2.h>
 #include <rclcpp/rclcpp.hpp>
 
+#include <tinyxml2.h>
 #include "geometry_msgs/msg/transform_stamped.hpp"
 
 #include <capabilities2_runner/topic_runner.hpp>

--- a/capabilities2_runner_nav2/package.xml
+++ b/capabilities2_runner_nav2/package.xml
@@ -16,9 +16,7 @@
   <depend>geometry_msgs</depend>
   <depend>capabilities2_msgs</depend>
   <depend>capabilities2_runner</depend>
-
-  <!-- system dependency -->
-  <depend>tinyxml2</depend>
+  <depend>tinyxml2_vendor</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/capabilities2_runner_prompt/CMakeLists.txt
+++ b/capabilities2_runner_prompt/CMakeLists.txt
@@ -17,24 +17,15 @@ find_package(pluginlib REQUIRED)
 find_package(prompt_msgs REQUIRED)
 find_package(capabilities2_msgs REQUIRED)
 find_package(capabilities2_runner REQUIRED)
+find_package(tinyxml2_vendor REQUIRED)
+find_package(TinyXML2 REQUIRED)  # provided by tinyxml2 upstream, or tinyxml2_vendor
 
-# Locate the static version of tinyxml2
-find_library(TINYXML2_LIB NAMES tinyxml2 PATHS /usr/local/lib NO_DEFAULT_PATH)
-
-if(NOT TINYXML2_LIB)
-  message(FATAL_ERROR "tinyxml2 library not found. Make sure it's installed as a static library.")
-endif()
-
-include_directories(include
-  /usr/local/include
+include_directories(
+  include
 )
 
 add_library(${PROJECT_NAME} SHARED
   src/prompt_runners.cpp
-)
-
-target_link_libraries(${PROJECT_NAME}
-  ${TINYXML2_LIB}
 )
 
 ament_target_dependencies(${PROJECT_NAME}
@@ -44,6 +35,7 @@ ament_target_dependencies(${PROJECT_NAME}
   prompt_msgs
   capabilities2_msgs
   capabilities2_runner
+  TinyXML2
 )
 
 pluginlib_export_plugin_description_file(capabilities2_runner plugins.xml)

--- a/capabilities2_runner_prompt/include/capabilities2_runner_prompt/prompt_occupancy_runner.hpp
+++ b/capabilities2_runner_prompt/include/capabilities2_runner_prompt/prompt_occupancy_runner.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include <tinyxml2.h>
 #include <string>
+#include <tinyxml2.h>
 #include <pluginlib/class_list_macros.hpp>
 #include <capabilities2_runner_prompt/prompt_service_runner.hpp>
 

--- a/capabilities2_runner_prompt/include/capabilities2_runner_prompt/prompt_plan_runner.hpp
+++ b/capabilities2_runner_prompt/include/capabilities2_runner_prompt/prompt_plan_runner.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include <tinyxml2.h>
 #include <string>
+#include <tinyxml2.h>
 #include <pluginlib/class_list_macros.hpp>
 #include <capabilities2_runner_prompt/prompt_service_runner.hpp>
 

--- a/capabilities2_runner_prompt/include/capabilities2_runner_prompt/prompt_pose_runner.hpp
+++ b/capabilities2_runner_prompt/include/capabilities2_runner_prompt/prompt_pose_runner.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include <tinyxml2.h>
 #include <string>
+#include <tinyxml2.h>
 #include <pluginlib/class_list_macros.hpp>
 #include <capabilities2_runner_prompt/prompt_service_runner.hpp>
 

--- a/capabilities2_runner_prompt/include/capabilities2_runner_prompt/prompt_service_runner.hpp
+++ b/capabilities2_runner_prompt/include/capabilities2_runner_prompt/prompt_service_runner.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include <tinyxml2.h>
 #include <string>
+#include <tinyxml2.h>
 #include <pluginlib/class_list_macros.hpp>
 #include <capabilities2_runner/service_runner.hpp>
 #include <prompt_msgs/msg/model_option.hpp>

--- a/capabilities2_runner_prompt/include/capabilities2_runner_prompt/prompt_text_runner.hpp
+++ b/capabilities2_runner_prompt/include/capabilities2_runner_prompt/prompt_text_runner.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include <tinyxml2.h>
 #include <string>
+#include <tinyxml2.h>
 #include <pluginlib/class_list_macros.hpp>
 #include <capabilities2_runner_prompt/prompt_service_runner.hpp>
 

--- a/capabilities2_runner_prompt/package.xml
+++ b/capabilities2_runner_prompt/package.xml
@@ -15,9 +15,7 @@
   <depend>prompt_msgs</depend>
   <depend>capabilities2_msgs</depend>
   <depend>capabilities2_runner</depend>
-
-  <!-- system dependency -->
-  <depend>tinyxml2</depend>
+  <depend>tinyxml2_vendor</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/capabilities2_server/CMakeLists.txt
+++ b/capabilities2_server/CMakeLists.txt
@@ -19,17 +19,12 @@ find_package(pluginlib REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(capabilities2_msgs REQUIRED)
 find_package(capabilities2_runner REQUIRED)
+find_package(tinyxml2_vendor REQUIRED)
+find_package(TinyXML2 REQUIRED)  # provided by tinyxml2 upstream, or tinyxml2_vendor
 find_package(backward_ros REQUIRED)
 
 find_package(PkgConfig)
 pkg_check_modules(UUID REQUIRED uuid)
-
-# Locate the static version of tinyxml2
-find_library(TINYXML2_LIB NAMES tinyxml2 PATHS /usr/local/lib NO_DEFAULT_PATH)
-
-if(NOT TINYXML2_LIB)
-  message(FATAL_ERROR "tinyxml2 library not found. Make sure it's installed as a static library.")
-endif()
 
 # Find SQLite3
 find_package(SQLite3)
@@ -40,7 +35,6 @@ find_package(yaml-cpp REQUIRED)
 include_directories(include
   ${SQLITE3_INCLUDE_DIRS}
   ${YAML_CPP_INCLUDE_DIRS}
-  /usr/local/include
   ${UUID_INCLUDE_DIRS}
 )
 
@@ -55,7 +49,6 @@ add_library(${PROJECT_NAME} SHARED
 target_link_libraries(${PROJECT_NAME}
   ${SQLITE3_LIBRARIES}
   ${YAML_CPP_LIBRARIES}
-  ${TINYXML2_LIB}
   ${UUID_LIBRARIES}
 )
 
@@ -67,6 +60,7 @@ ament_target_dependencies(${PROJECT_NAME}
   rclcpp_components
   capabilities2_msgs
   capabilities2_runner
+  TinyXML2
   SQLite3
   yaml-cpp
   UUID
@@ -96,7 +90,6 @@ add_executable(${PROJECT_NAME}_node
 
 target_link_libraries(${PROJECT_NAME}_node
   ${UUID_LIBRARIES}
-  ${TINYXML2_LIB}
   ${SQLITE3_LIBRARIES}
   ${YAML_CPP_LIBRARIES}
 )
@@ -109,6 +102,7 @@ ament_target_dependencies(${PROJECT_NAME}_node
   rclcpp_components
   capabilities2_msgs
   capabilities2_runner
+  TinyXML2
   SQLite3
   yaml-cpp
   UUID
@@ -125,7 +119,6 @@ target_link_libraries(test_capabilities_server
   ${PROJECT_NAME}
   ${SQLITE3_LIBRARIES}
   ${YAML_CPP_LIBRARIES}
-  ${TINYXML2_LIB}
   ${UUID_LIBRARIES}
 )
 add_dependencies(test_capabilities_server ${PROJECT_NAME})

--- a/capabilities2_server/include/capabilities2_server/capabilities_api.hpp
+++ b/capabilities2_server/include/capabilities2_server/capabilities_api.hpp
@@ -6,9 +6,9 @@
 #include <vector>
 #include <functional>
 
+#include <tinyxml2.h>
 #include <uuid/uuid.h>
 #include <yaml-cpp/yaml.h>
-#include <tinyxml2.h>
 
 #include <rclcpp/rclcpp.hpp>
 

--- a/capabilities2_server/include/capabilities2_server/capabilities_server.hpp
+++ b/capabilities2_server/include/capabilities2_server/capabilities_server.hpp
@@ -7,9 +7,7 @@
 #include <fstream>
 #include <filesystem>
 #include <functional>
-
 #include <stdlib.h>
-
 #include <tinyxml2.h>
 
 #include <rclcpp/rclcpp.hpp>

--- a/capabilities2_server/package.xml
+++ b/capabilities2_server/package.xml
@@ -22,11 +22,10 @@
   <depend>rclcpp_components</depend>
   <depend>capabilities2_msgs</depend>
   <depend>capabilities2_runner</depend>
-  <depend>capabilities2_utils</depend>
+  <depend>tinyxml2_vendor</depend>
 
   <!-- system dependency -->
   <depend>yaml-cpp</depend>
-  <depend>tinyxml2</depend>
   <depend>libsqlite3-dev</depend>
   <depend>uuid</depend>
   <depend>backward_ros</depend>


### PR DESCRIPTION
# resolved tinyxml2 to use ros-provided version using tinyxml2-vendor package

## Description

The system now uses tinyxml2 provided by the ros eco system. This version is provided through tinyxml2-vendor package which they consider as a temporary package. Independent files started version mismatches with this package.

Fixes #21

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified via system running
