### PR TITLE
updated issue with package version numbers

### DIFF
--- a/capabilities2/package.xml
+++ b/capabilities2/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>capabilities2</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>
     meta-package for the capabilities2 framework
   </description>

--- a/capabilities2_events/package.xml
+++ b/capabilities2_events/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>capabilities2_events</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>
     Event subsystem for the capabilities2 framework
   </description>

--- a/capabilities2_msgs/package.xml
+++ b/capabilities2_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>capabilities2_msgs</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>
     This package provides message service and action formats for capabilities2 interface
   </description>

--- a/capabilities2_runner/package.xml
+++ b/capabilities2_runner/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>capabilities2_runner</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>
     Package for capabilities2 runners, plugin base classes, system-level and capability specific runner plugins
   </description>

--- a/capabilities2_server/package.xml
+++ b/capabilities2_server/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>capabilities2_server</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>
     Package that implements the capabilities2 service, a successor to capabilities
   </description>


### PR DESCRIPTION
This pull request updates the version numbers for all core `capabilities2` packages from `0.2.0` to `0.3.0`. No other changes are included.

- Updated package versions:
  * [`capabilities2/package.xml`](diffhunk://#diff-7fc426823e1b440d7ba6f5f1b24ed7bc48591441a18370cef2d520ace0796cd8L4-R4): Version updated to `0.3.0`
  * [`capabilities2_events/package.xml`](diffhunk://#diff-36c2bd05a4024d6b18ace72b691066d3822050fbc0a89131e2011f30fb88591dL4-R4): Version updated to `0.3.0`
  * [`capabilities2_msgs/package.xml`](diffhunk://#diff-075edff2c6a9642a045026d4dc4e18320dee5608f7f7d7e7aaaf628bb6a02163L4-R4): Version updated to `0.3.0`
  * [`capabilities2_runner/package.xml`](diffhunk://#diff-c8954cd6341471589a2c60a0acf86a8ba8dcc1c6a477bd078b4488af8540586dL4-R4): Version updated to `0.3.0`
  * [`capabilities2_server/package.xml`](diffhunk://#diff-5f1710e51cb771f90a548ac102c9adc68d8f6a72b4084d79d06da38091531a73L4-R4): Version updated to `0.3.0`